### PR TITLE
Change to md5 as default and update HashRing signature

### DIFF
--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -19,7 +19,7 @@ def ring():
         nodes={'node1': 1,
                'node2': 1,
                'node3': 1},
-        compat=True)
+        hash_fn='ketama')
     return ring
 
 
@@ -171,7 +171,7 @@ def test_weight_fn():
         nodes={'node1': 1, 'node2': 1, 'node3': 1},
         replicas=4,
         vnodes=40,
-        compat=True,
+        hash_fn='ketama',
         weight_fn=weight_fn)
 
     assert ring.distribution['node1'] == 80
@@ -189,7 +189,7 @@ def test_weight_fn():
             nodes={'node1': 1, 'node2': 1, 'node3': 1},
             replicas=4,
             vnodes=40,
-            compat=True,
+            hash_fn='ketama',
             weight_fn=12)
 
     with pytest.raises(TypeError):
@@ -197,12 +197,12 @@ def test_weight_fn():
             nodes={'node1': 1, 'node2': 1, 'node3': 1},
             replicas=4,
             vnodes=40,
-            compat=True,
+            hash_fn='ketama',
             weight_fn='coconut')
 
 
 def test_ring_growth_ketama(ring):
-    add_ring = HashRing(compat=True)
+    add_ring = HashRing(hash_fn='ketama')
     for nodename in ring.nodes:
         add_ring.add_node(nodename)
 

--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -19,8 +19,6 @@ def ring():
         nodes={'node1': 1,
                'node2': 1,
                'node3': 1},
-        replicas=4,
-        vnodes=40,
         compat=True)
     return ring
 
@@ -31,8 +29,6 @@ def ring_fast():
         nodes={'node1': 1,
                'node2': 1,
                'node3': 1},
-        replicas=4,
-        vnodes=40,
         compat=False)
     return ring
 
@@ -48,10 +44,10 @@ def test_ring_size(ring, ring_fast):
     assert ring.size == len(ring._ring)
     assert ring.size == len(ring.get_points())
 
-    assert ring_fast.size == len(ring.get_nodes()) * 160
-    assert ring_fast.size == len(ring._keys)
-    assert ring_fast.size == len(ring._ring)
-    assert ring_fast.size == len(ring.get_points())
+    assert ring_fast.size == len(ring_fast.get_nodes()) * 160
+    assert ring_fast.size == len(ring_fast._keys)
+    assert ring_fast.size == len(ring_fast._ring)
+    assert ring_fast.size == len(ring_fast.get_points())
 
     assert ring.size == ring_fast.size
 
@@ -79,7 +75,6 @@ def test_aliases(ring):
     assert ring.remove_node == ring.__delitem__
     assert ring.continuum == ring.ring
     assert ring.nodes == ring.conf
-    assert ring.regenerate == ring._create_ring
 
 
 def test_ketama_ring_hashi(ring):
@@ -140,7 +135,7 @@ def test_conf():
 
 def test_empty_ring():
     ring = HashRing()
-    assert ring.get('test') == None
+    assert ring.get('test') is None
 
 
 def test_methods_return_types(ring):
@@ -161,9 +156,9 @@ def test_methods_return_types(ring):
 
 
 def test_print_without_error(ring):
-    assert ring.print_continuum() == None
+    assert ring.print_continuum() is None
     ring = HashRing()
-    assert ring.print_continuum() == None
+    assert ring.print_continuum() is None
 
 
 def test_with_non_str_objects(ring):
@@ -173,9 +168,7 @@ def test_with_non_str_objects(ring):
 
 def test_weight_fn():
     ring = HashRing(
-        nodes={'node1': 1,
-               'node2': 1,
-               'node3': 1},
+        nodes={'node1': 1, 'node2': 1, 'node3': 1},
         replicas=4,
         vnodes=40,
         compat=True,
@@ -193,29 +186,36 @@ def test_weight_fn():
 
     with pytest.raises(TypeError):
         ring = HashRing(
-        nodes={'node1': 1,
-               'node2': 1,
-               'node3': 1},
-        replicas=4,
-        vnodes=40,
-        compat=True,
-        weight_fn=12)
+            nodes={'node1': 1, 'node2': 1, 'node3': 1},
+            replicas=4,
+            vnodes=40,
+            compat=True,
+            weight_fn=12)
 
     with pytest.raises(TypeError):
         ring = HashRing(
-        nodes={'node1': 1,
-               'node2': 1,
-               'node3': 1},
-        replicas=4,
-        vnodes=40,
-        compat=True,
-        weight_fn='coconut')
+            nodes={'node1': 1, 'node2': 1, 'node3': 1},
+            replicas=4,
+            vnodes=40,
+            compat=True,
+            weight_fn='coconut')
 
 
-def test_ring_growth(ring):
-    add_ring = HashRing()
+def test_ring_growth_ketama(ring):
+    add_ring = HashRing(compat=True)
     for nodename in ring.nodes:
         add_ring.add_node(nodename)
 
+    assert ring._nodes == add_ring._nodes
     assert ring.ring == add_ring.ring
     assert ring.distribution == add_ring.distribution
+
+
+def test_ring_growth_meta(ring_fast):
+    add_ring = HashRing(compat=False)
+    for nodename in ring_fast.nodes:
+        add_ring.add_node(nodename)
+
+    assert ring_fast._nodes == add_ring._nodes
+    assert ring_fast.ring == add_ring.ring
+    assert ring_fast.distribution == add_ring.distribution

--- a/uhashring/monkey.py
+++ b/uhashring/monkey.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
 
-import types
 from uhashring import HashRing
 
 __all__ = ['patch_memcache']

--- a/uhashring/ring.py
+++ b/uhashring/ring.py
@@ -9,24 +9,20 @@ from uhashring.ring_meta import MetaRing
 class HashRing(object):
     """Implement a consistent hashing ring."""
 
-    def __init__(self,
-                 nodes=[],
-                 replicas=None,
-                 vnodes=None,
-                 compat=True,
-                 weight_fn=None,
-                 hash_fn=None):
+    def __init__(self, nodes=[], **kwargs):
         """Create a new HashRing given the implementation.
 
         :param nodes: nodes used to create the continuum (see doc for format).
-        :param replicas: (obsolete) number of replicas per node.
-        :param vnodes: default number of vnodes per node.
-        :param compat: (obsolete) use a ketama compatible hash calculation.
-        :param weight_fn: use this function to calculate the node's weight.
         :param hash_fn: use this callable function to hash keys, can be set to
                         'ketama' to use the ketama compatible implementation.
+        :param vnodes: default number of vnodes per node.
+        :param weight_fn: use this function to calculate the node's weight.
         """
-        if compat is True or hash_fn == 'ketama':
+        hash_fn = kwargs.get('hash_fn', None)
+        vnodes = kwargs.get('vnodes', None)
+        weight_fn = kwargs.get('weight_fn', None)
+
+        if hash_fn == 'ketama':
             if vnodes is None:
                 vnodes = 40
             self.runtime = KetamaRing()

--- a/uhashring/ring_ketama.py
+++ b/uhashring/ring_ketama.py
@@ -1,0 +1,85 @@
+# -*- coding: utf-8 -*-
+
+from bisect import insort
+from collections import Counter
+from hashlib import md5
+from sys import version_info
+
+
+class KetamaRing(object):
+    """Implement a ketama compatible consistent hashing ring."""
+
+    def __init__(self):
+        """Create a new HashRing.
+        """
+        self._distribution = Counter()
+        self._keys = []
+        self._nodes = {}
+        self._replicas = 4
+        self._ring = {}
+
+        if version_info >= (3, ):
+            self._listbytes = lambda x: x
+
+    def hashi(self, key, replica=0):
+        """Returns a ketama compatible hash from the given key.
+        """
+        dh = self._listbytes(md5(str(key).encode('utf-8')).digest())
+        rd = replica * 4
+        return (
+            (dh[3 + rd] << 24) | (dh[2 + rd] << 16) |
+            (dh[1 + rd] << 8) | dh[0 + rd])
+
+    def _hashi_weight_generator(self, node_name, node_conf):
+        """Calculate the weight factor of the given node and
+        yield its hash key for every configured replica.
+
+        :param node_name: the node name.
+        """
+        ks = (node_conf['vnodes'] * len(self._nodes) *
+              node_conf['weight']) // self._weight_sum
+        for w in range(0, ks):
+            w_node_name = '%s-%s' % (node_name, w)
+            for i in range(0, self._replicas):
+                yield self.hashi(w_node_name, replica=i)
+
+    @staticmethod
+    def _listbytes(data):
+        """Python 2 compatible int iterator from str.
+
+        :param data: the string to int iterate upon.
+        """
+        return map(ord, data)
+
+    def _create_ring(self, nodes):
+        """Generate a ketama compatible continuum/ring.
+        """
+        _weight_sum = 0
+        for node_conf in self._nodes.values():
+            _weight_sum += node_conf['weight']
+        self._weight_sum = _weight_sum
+
+        _distribution = Counter()
+        _keys = []
+        _ring = {}
+        for node_name, node_conf in self._nodes.items():
+            for h in self._hashi_weight_generator(node_name, node_conf):
+                _ring[h] = node_name
+                insort(_keys, h)
+                _distribution[node_name] += 1
+        self._distribution = _distribution
+        self._keys = _keys
+        self._ring = _ring
+
+    def _remove_node(self, node_name):
+        """Remove the given node from the continuum/ring.
+
+        :param node_name: the node name.
+        """
+        try:
+            self._nodes.pop(node_name)
+        except:
+            raise KeyError('node \'{}\' not found, available nodes: {}'.format(
+                node_name, self._nodes.keys()))
+        else:
+            self._create_ring(self._nodes)

--- a/uhashring/ring_meta.py
+++ b/uhashring/ring_meta.py
@@ -1,0 +1,52 @@
+# -*- coding: utf-8 -*-
+
+from collections import Counter
+from hashlib import md5
+
+
+class MetaRing(object):
+    """Implement a tunable consistent hashing ring."""
+
+    def __init__(self, hash_fn):
+        """Create a new HashRing.
+
+        :param hash_fn: use this callable function to hash keys.
+        """
+        self._distribution = Counter()
+        self._keys = []
+        self._nodes = {}
+        self._ring = {}
+
+        if hash_fn and not hasattr(hash_fn, '__call__'):
+            raise TypeError('hash_fn should be a callable function')
+        self._hash_fn = hash_fn
+
+    def hashi(self, key):
+        """Returns an integer derived from the md5 hash of the given key.
+        """
+        return int(md5(str(key).encode('utf-8')).hexdigest(), 16)
+
+    def _create_ring(self, nodes):
+        """Generate a ketama compatible continuum/ring.
+        """
+        for node_name, node_conf in nodes:
+            for w in range(0, node_conf['vnodes'] * node_conf['weight']):
+                self._distribution[node_name] += 1
+                self._ring[self.hashi('%s-%s' % (node_name, w))] = node_name
+        self._keys = sorted(self._ring.keys())
+
+    def _remove_node(self, node_name):
+        """Remove the given node from the continuum/ring.
+
+        :param node_name: the node name.
+        """
+        try:
+            node_conf = self._nodes.pop(node_name)
+        except:
+            raise KeyError('node \'{}\' not found, available nodes: {}'.format(
+                node_name, self._nodes.keys()))
+        else:
+            self._distribution.pop(node_name)
+            for w in range(0, node_conf['vnodes'] * node_conf['weight']):
+                del self._ring[self.hashi('%s-%s' % (node_name, w))]
+            self._keys = sorted(self._ring.keys())


### PR DESCRIPTION
This is the result of the discussions on issue #6 which will end up as uhashring 1.0 to make a point on the signature change.

Documentation is updated to reflect the change.

> This change was motivated by the fact that the ketama hash function has more chances of collisions and thus requires a complete ring regeneration when the nodes topology change. This could lead to degraded performances on rapidly changing or unstable environments where nodes keep going down and up. The md5 implementation provides a linear performance when adding or removing a node from the ring!

@bjhockley would you please review, test & confirm you're in line with this change please?