### PR TITLE
Use hash_fn parameter

### DIFF
--- a/uhashring/ring_meta.py
+++ b/uhashring/ring_meta.py
@@ -19,7 +19,7 @@ class MetaRing(object):
 
         if hash_fn and not hasattr(hash_fn, '__call__'):
             raise TypeError('hash_fn should be a callable function')
-        self._hash_fn = hash_fn or lambda key: int(md5(str(key).encode('utf-8')).hexdigest(), 16)
+        self._hash_fn = hash_fn or (lambda key: int(md5(str(key).encode('utf-8')).hexdigest(), 16))
 
     def hashi(self, key):
         """Returns an integer derived from the md5 hash of the given key.

--- a/uhashring/ring_meta.py
+++ b/uhashring/ring_meta.py
@@ -19,12 +19,12 @@ class MetaRing(object):
 
         if hash_fn and not hasattr(hash_fn, '__call__'):
             raise TypeError('hash_fn should be a callable function')
-        self._hash_fn = hash_fn
+        self._hash_fn = hash_fn or lambda key: int(md5(str(key).encode('utf-8')).hexdigest(), 16)
 
     def hashi(self, key):
         """Returns an integer derived from the md5 hash of the given key.
         """
-        return int(md5(str(key).encode('utf-8')).hexdigest(), 16)
+        return self._hash_fn(key)
 
     def _create_ring(self, nodes):
         """Generate a ketama compatible continuum/ring.


### PR DESCRIPTION
Seems like `hash_fn` and `_hash_fn` aren't used. This will default `self._hash_fn` to a lambda of the md5 based hash function if `hash_fn is None`.