### PR TITLE
Expose replicas argument for KetamaRing

### DIFF
--- a/tests/test_implementation.py
+++ b/tests/test_implementation.py
@@ -237,3 +237,9 @@ def test_hash_fn():
     nodes = ["172.31.1.0", "172.31.1.125", "172.31.1.202"]
     ring = HashRing(nodes, hash_fn=hash_fn)
     assert ring.hashi("coconut") == "coconut_hash"
+
+
+def test_ketama_replica_arg():
+    ring = HashRing([1, 2, 3, 4], hash_fn="ketama", replicas=3)
+    assert ring.runtime._replicas == 3
+    assert ring.get_node("foo") == 4

--- a/uhashring/ring.py
+++ b/uhashring/ring.py
@@ -21,9 +21,10 @@ class HashRing:
         weight_fn = kwargs.get("weight_fn", None)
 
         if hash_fn == "ketama":
+            ketama_args = {k: v for k, v in kwargs.items() if k in ("replicas",)}
             if vnodes is None:
                 vnodes = 40
-            self.runtime = KetamaRing()
+            self.runtime = KetamaRing(**ketama_args)
         else:
             if vnodes is None:
                 vnodes = 160

--- a/uhashring/ring_ketama.py
+++ b/uhashring/ring_ketama.py
@@ -6,12 +6,12 @@ from hashlib import md5
 class KetamaRing:
     """Implement a ketama compatible consistent hashing ring."""
 
-    def __init__(self):
+    def __init__(self, replicas=4):
         """Create a new HashRing."""
         self._distribution = Counter()
         self._keys = []
         self._nodes = {}
-        self._replicas = 4
+        self._replicas = replicas
         self._ring = {}
 
         self._listbytes = lambda x: x


### PR DESCRIPTION
The KetamaRing had a hardcoded value of 4 replicas. When migrating from
another library that uses a different replicacount uhashlib would not
produce the same values. To fix this we expose the replicas as a public
API and let the users decide how many replicas they want. This is for
example the case with the hash-lib pypi package, which uses 3 replicas.

---

Found this library when looking for a replacement for `hash-ring`. Sadly `hash-ring` uses `replicas=3` and I cannot change that value in my production landscape, so I thought we could make that parameter configurable. At the moment I'm monkey-patching `uhashring`, which is not a very nice solution.

For the test I used a value that generates a different value for `replicas=4` than for `replicas=3` to test that the latter is really being used.